### PR TITLE
Bytter til å bruke sendt_til_arbeidsgiver_kandidatliste

### DIFF
--- a/key_results_ny.qmd
+++ b/key_results_ny.qmd
@@ -80,14 +80,11 @@ antall_kandidatlister_der_minst_en_kandidat_i_prioritert_maalgruppe_fikk_jobben 
 
 ```{python}
 query = f"""
-    with id_siste_utfall_per_kandidat_per_liste as (
-        select max(id) from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall 
-        group by aktorid, kandidatlisteid
-    ),
-    presentert_utfall as (
-        select * from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall 
-        where id in (select * from id_siste_utfall_per_kandidat_per_liste)
-        and (utfall = 'FATT_JOBBEN' or utfall = 'PRESENTERT')
+    with presentert_utfall as (
+        select * from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+        inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
+        inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
+        where sendt_til_arbeidsgivers_kandidatliste = true
     )
     select count(distinct kandidatliste_id)
     from`rekrutteringsbistand_statistikk_pg15.kandidatliste` as kandidatliste
@@ -215,18 +212,15 @@ query = f"""
     -- Tall for juni for eks. vil være ferdigberegnet i slutten av september. Andelen kan bare øke etter måneden har gått.
 
 
-    with id_siste_utfall_per_kandidat_per_liste as (
-            select max(id) from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
-            group by aktorid, kandidatlisteid
-        ),
-        presentert_utfall as (
-            select * from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
-            where id in (select * from id_siste_utfall_per_kandidat_per_liste)
-                and (utfall = 'FATT_JOBBEN' or utfall = 'PRESENTERT')
+    with presentert_utfall as (
+            select kandidatutfall.tidspunkt, kandidatutfall.kandidatlisteid from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+            inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
+            inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
+            where sendt_til_arbeidsgivers_kandidatliste = true
         )
         select 
-          format_datetime('%Y-%m', kandidatliste.stilling_opprettet_tidspunkt) as tidspunkt_stilling_opprettet_yearmonth,
-          count(distinct kandidatliste_id) as antall_stillinger
+            format_datetime('%Y-%m', kandidatliste.stilling_opprettet_tidspunkt) as tidspunkt_stilling_opprettet_yearmonth,
+            count(distinct kandidatliste_id) as antall_stillinger
         from`rekrutteringsbistand_statistikk_pg15.kandidatliste` as kandidatliste
                     inner join presentert_utfall
                     on presentert_utfall.kandidatlisteid = kandidatliste.kandidatliste_id
@@ -322,14 +316,11 @@ df_antall_kandidatlister_der_minst_en_kandidat_i_prioritert_maalgruppe_fikk_jobb
 
 ```{python}
 query = f"""
-    with id_siste_utfall_per_kandidat_per_liste as (
-        select max(id) from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
-        group by aktorid, kandidatlisteid
-    ),
-    presentert_utfall as (
-        select * from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
-        where id in (select * from id_siste_utfall_per_kandidat_per_liste)
-            and (utfall = 'FATT_JOBBEN' or utfall = 'PRESENTERT')
+    with presentert_utfall as (
+        select kandidatutfall.tidspunkt, kandidatutfall.kandidatlisteid from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+            inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
+            inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
+            where sendt_til_arbeidsgivers_kandidatliste = true
     )
     select 
         format_datetime('%Y-%m-%d', unike_kandidatlister.stilling_opprettet_tidspunkt) as tidspunkt_stilling_opprettet_yearmonthday,

--- a/key_results_ny.qmd
+++ b/key_results_ny.qmd
@@ -81,7 +81,7 @@ antall_kandidatlister_der_minst_en_kandidat_i_prioritert_maalgruppe_fikk_jobben 
 ```{python}
 query = f"""
     with presentert_utfall as (
-        select * from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+        select distinct kandidatlisteid, aktorid from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
         inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
         inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
         where sendt_til_arbeidsgivers_kandidatliste = true
@@ -213,7 +213,7 @@ query = f"""
 
 
     with presentert_utfall as (
-            select kandidatutfall.tidspunkt, kandidatutfall.kandidatlisteid from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+            select distinct kandidatutfall.kandidatlisteid, kandidatutfall.aktorid, kandidatutfall.tidspunkt from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
             inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
             inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
             where sendt_til_arbeidsgivers_kandidatliste = true
@@ -317,7 +317,7 @@ df_antall_kandidatlister_der_minst_en_kandidat_i_prioritert_maalgruppe_fikk_jobb
 ```{python}
 query = f"""
     with presentert_utfall as (
-        select kandidatutfall.tidspunkt, kandidatutfall.kandidatlisteid from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
+        select distinct kandidatutfall.kandidatlisteid, kandidatutfall.aktorid, kandidatutfall.tidspunkt from `rekrutteringsbistand_statistikk_pg15.kandidatutfall` as kandidatutfall
             inner join `kandidat_api.veilkandidat` k on k.aktor_id = kandidatutfall.aktorid
             inner join `kandidat_api.utfallsendring` u on u.veilkandidat_db_id = k.db_id
             where sendt_til_arbeidsgivers_kandidatliste = true


### PR DESCRIPTION
Bytter til å bruke sendt_til_arbeidsgivers_kandidatliste i stedet for presentert. Denne statusen settes kun når CV er delt med arbeidsgiver via RB